### PR TITLE
More elegant ip addage

### DIFF
--- a/app/server/modules/organization/company_controller.py
+++ b/app/server/modules/organization/company_controller.py
@@ -52,8 +52,7 @@ def create_company():
             domain=company_domain
     )
      # add the company to the database
-    db.session.add(company)
-    db.session.commit()
+    
 
     # Create 100 employees that work for the company
     # Specify how long they have been working at the company
@@ -66,20 +65,17 @@ def create_company():
                             days_since_hire=days_since_hire
                         )
         employees.append(new_employee)
-
+        db.session.add(new_employee)
         # this is not efficient ... but part of a workaround to avoid IP collisions
         # db must be aware of all employees during creation process
-        db.session.add(new_employee)
-        db.session.commit()
         upload_employee_to_azure(new_employee)
 
-       
 
     print("Generating company employees")
     # Add the employees to the database
     # add the employees to Azure
-    for employee in employees:
-        db.session.add(employee)
+    db.session.add(company)
+    db.session.commit()
         
 
         


### PR DESCRIPTION
Storing the employee count in local variable on the Company object -> so we don't have to query to company everytime

```python
def get_employee_count(self) -> int:
        """
        Get number of child employee object
        If count_employees is 0 -> pull this number by querying the database
        Else get cached number
        """
        if self.count_employees == 0:
            self.count_employees = self.employees.count()
        
        return self.count_employees


  def generate_ip(self) -> str:
      """Assign the employee an IP on the local network"""
      #  IP is 192.168.0.2 + count of employee (using CIDR addition)
      # this tries to reduce chance of IP collisions
  
      ip = format(ipaddress.IPv4Address('192.168.0.2') + self.get_employee_count())
      # increment this -> so we know we have one more employee 
      # without needing to query the DB
      self.count_employees +=1
      
      return ip
```
