### PR TITLE
added several changes to email generation so the data is cleaner. Ren…

### DIFF
--- a/app/server/modules/actors/Actor.py
+++ b/app/server/modules/actors/Actor.py
@@ -226,10 +226,12 @@ class Actor(Base):
         Assemble a subject line using list of theme words from the Actor object
         """
         subjects = Actor.string_to_list(self.subjects) 
+        # give it some prefixes for variety
+        prefix  = random.choices(["", "RE: ", "FW: ", "RE:RE: "], weights=(60, 20, 15, 5), k=1)[0]
         if subjects:
-            return random.choice(subjects)
+            return prefix + random.choice(subjects) 
         else:
-            return sentenceGenerator.genSentence()
+            return prefix + sentenceGenerator.genSentence() 
 
 
     def get_sender_address(self) -> str:

--- a/app/server/modules/email/email.py
+++ b/app/server/modules/email/email.py
@@ -24,7 +24,7 @@ class Email:
     """
 
     def __init__(self, sender: str, recipient: str, subject: str, time: float = None, authenticity: int = None,
-                 accepted: bool = True, link: str = None, domain: str = "", reply_to: str = None, opened: bool = False, actor: Actor = None):
+                 verdict: str = "", link: str = None, domain: str = "", reply_to: str = None, opened: bool = False, actor: Actor = None):
 
         self.time = time or datetime.datetime.now().strftime("%a %b %d %H:%M:%S %Y")
         self.subject = subject
@@ -36,10 +36,7 @@ class Email:
         self.link = link
         self.actor = actor
 
-        if not accepted:
-            self.accepted = random.choice([True, False])
-        else:
-            self.accepted = accepted
+        self.verdict = verdict
 
         if not link:
             # this should not occur
@@ -57,6 +54,11 @@ class Email:
         else:
             self.authenticity = authenticity
 
+    
+    @property
+    def accepted(self):
+        return self.verdict != "BLOCKED"
+
     def stringify(self) -> "dict[str, str]":
         """return json object with email attributes"""
         # if time is a timestamp convert to datetime string
@@ -71,7 +73,7 @@ class Email:
             "reply_to": self.reply_to,
             "recipient": self.recipient,
             "subject": self.subject,
-            "accepted": self.accepted,
+            "verdict": self.verdict,
             "link": self.link
         }
 
@@ -84,7 +86,7 @@ class Email:
                 "reply_to": "string",
                 "recipient": "string",
                 "subject": "string",
-                "accepted": "bool",
+                "verdict": "string",
                 "link": "string"
             }
         )

--- a/app/server/modules/email/email_controller.py
+++ b/app/server/modules/email/email_controller.py
@@ -106,7 +106,7 @@ def gen_inbound_mail(recipients: "list[Employee]", actor: Actor, actor_domains:"
     link, domain = get_link(actor, actor_domains, return_domain=True)
     sender = actor.get_sender_address()
     reply_to = actor.get_sender_address() if actor.spoofs_email else sender
-    subject = actor.get_email_subject()
+    subject = "[External] " + actor.get_email_subject()
 
     for recipient in recipients:
         email = Email(
@@ -118,7 +118,7 @@ def gen_inbound_mail(recipients: "list[Employee]", actor: Actor, actor_domains:"
             link=link,
             domain=domain,
             actor=actor,
-            accepted=random.choices([True, False], weights=(70, 30), k=1)[0],
+            verdict=random.choices(["CLEAN", "SUSPICIOUS", "BLOCKED"], weights=(65, 20, 10), k=1)[0],
             authenticity=actor.effectiveness
         )
 
@@ -142,7 +142,7 @@ def gen_outbound_mail(sender: Employee, actor: Actor, actor_domains:"list[str]",
         recipient=fake.ascii_email(),
         subject=actor.get_email_subject(),
         link=get_link(actor, actor_domains=actor_domains),
-        accepted=True
+        verdict=""
     )
 
     send_email_to_azure(email)
@@ -158,7 +158,7 @@ def gen_internal_mail(sender: Employee, recipient: Employee, actor: Actor, actor
         recipient=recipient.email_addr,
         subject=actor.get_email_subject(),
         link=get_link(actor, actor_domains=actor_domains),
-        accepted=True,
+        verdict="",
         authenticity=INTERNAL_EMAIL_AUTHENTICITY
     )
 
@@ -177,9 +177,11 @@ def gen_partner_mail(employee: Employee, partner_domain: str, actor: Actor, acto
     if directionality == EmailType.INBOUND.value:
         sender = partner_email
         recipient = employee.email_addr
+        verdict="CLEAN"
     else:
         sender = employee.email_addr
         recipient = partner_email
+        verdict=""
 
     email = Email(
         time=time,
@@ -187,7 +189,7 @@ def gen_partner_mail(employee: Employee, partner_domain: str, actor: Actor, acto
         recipient=recipient,
         subject=actor.get_email_subject(),
         link=get_link(actor, actor_domains),
-        accepted=True,
+        verdict= verdict,
         authenticity=PARTNER_EMAIL_AUTHENTICITY
     )
 

--- a/app/server/modules/inbound_browsing/inboundEvent.py
+++ b/app/server/modules/inbound_browsing/inboundEvent.py
@@ -42,7 +42,7 @@ class InboundBrowsingEvent:
     @staticmethod
     def get_kql_repr():
         return (
-            "InboundBrowsing",         # table name
+            "InboundNetworkEvents",         # table name
             {                           # type dict
                   "timestamp": "datetime",
                   "method": "string",

--- a/app/server/modules/inbound_browsing/inbound_browsing_controller.py
+++ b/app/server/modules/inbound_browsing/inbound_browsing_controller.py
@@ -141,4 +141,4 @@ def upload_event_to_azure(event):
     from app.server.game_functions import LOG_UPLOADER
     LOG_UPLOADER.send_request(
             data = [event.stringify()],
-            table_name= "InboundBrowsing")
+            table_name= "InboundNetworkEvents")

--- a/app/server/modules/outbound_browsing/browsing_controller.py
+++ b/app/server/modules/outbound_browsing/browsing_controller.py
@@ -53,7 +53,7 @@ def browse_random_website(employees:"list[Employee]", actor:Actor, count_browsin
                 user_agent=employee.user_agent,
                 url=link,
             )
-            upload_event_to_azure(outbound_event, "OutboundBrowsing")    
+            upload_event_to_azure(outbound_event, "OutboundNetworkEvents")    
 
 
 def browse_website(employee:Employee, link:str, time:float, method: str = None):
@@ -66,7 +66,7 @@ def browse_website(employee:Employee, link:str, time:float, method: str = None):
         method = method
     )
     
-    upload_event_to_azure(event, "OutboundBrowsing")
+    upload_event_to_azure(event, "OutboundNetworkEvents")
 
 
 def upload_event_to_azure(events, table_name:str):

--- a/app/server/modules/outbound_browsing/outboundEvent.py
+++ b/app/server/modules/outbound_browsing/outboundEvent.py
@@ -42,7 +42,7 @@ class OutboundEvent:
     @staticmethod
     def get_kql_repr():
         return (
-            "OutboundBrowsing",         # table name
+            "OutboundNetworkEvents",         # table name
             {                           # type dict
                   "timestamp": "datetime",
                   "method": "string",


### PR DESCRIPTION
…amed browsing tables in prod to have 'networking'

External emails now have an [External]  tag to denote directionality
All emails have added potentian FW/RE prefix in the subject to make more realistic
`[External] FW: Impact the have key take we any of to hope`

Email accepted column has been changed to verdict
Verdict can be `CLEAN`, `SUSPICIOUS`, `BLOCKED` or blank
Only inbound emails receive a verdict

Renamed 
`InboundBrowsing` -> `InboundNetworkEvents`
`OutboundBrowsing` -> `OutboundNetworkEvents`